### PR TITLE
add TYPO3_CONTEXT for typo3 console

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,10 @@ This task is a wrapper for the TYPO3 CMS extension "typo3_console" which can be 
 A typical call cna look like that: 
 
 ```
+deployment:
+  ...
+  typo3-context: Staging
+  ...
 tasks:
   ...
   post-release:

--- a/Tasks/Typo3Console.php
+++ b/Tasks/Typo3Console.php
@@ -46,8 +46,13 @@ class Typo3Console extends AbstractTask
             );
         }
 
+        $environmentCommand = '';
+        if ($env = $this->getConfig()->deployment('typo3-context')) {
+            $environmentCommand = 'export TYPO3_CONTEXT="' . $env . '" && ';
+        }
+
         $command = sprintf(
-            'cd %s && %s ./typo3cms %s',
+            $environmentCommand . 'cd %s && %s ./typo3cms %s',
             $this->getConfig()->deployment('document-root'),
             $this->getParameter('php', ''),
             $command


### PR DESCRIPTION
With this PR it's possible to configure the TYPO3_CONTEXT environment in the general config. Needed on systems with multiple TYPO3 instances, only difference are the TYPO3_CONTEXT environment variable